### PR TITLE
Remove isPrimary from tap event

### DIFF
--- a/src/tap.js
+++ b/src/tap.js
@@ -46,7 +46,7 @@
       'up'
     ],
     down: function(inEvent) {
-      if (inEvent.isPrimary && !inEvent.tapPrevented) {
+      if (!inEvent.tapPrevented) {
         pointermap.set(inEvent.pointerId, {
           target: inEvent.target,
           buttons: inEvent.buttons,


### PR DESCRIPTION
There is no point in limiting the tap to the primary pointer.

Use case: imagine the primary pointer is being busy doing a drag & drop operation while another pointer wants to tap somewhere.
