### PR TITLE
Add examples from PointerEvents

### DIFF
--- a/samples/paint/index.html
+++ b/samples/paint/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<head>
+<meta name="viewport" content="width=device-width">
+<meta charset="UTF-8">
+<title>PointerEvents Paint</title>
+</head>
+
+<style>
+html, body {
+  padding: 0; margin: 0;
+  overflow: hidden;
+}
+  canvas {
+    background: lightgreen;
+    margin: 0 auto;
+    overflow: hidden;
+  }
+</style>
+
+<canvas width="800" height="600" touch-action="none"></canvas>
+
+<!-- Pointer events library. -->
+<script src="../../polymer-gestures.js"></script>
+<script src="paint.js"></script>
+<script>
+window.addEventListener('load', init);
+
+function init() {
+  var painter = new Paint({el: document.querySelector('canvas')});
+};
+</script>

--- a/samples/paint/paint.js
+++ b/samples/paint/paint.js
@@ -1,0 +1,110 @@
+// shim layer with setTimeout fallback
+window.requestAnimFrame = (function(){
+  return  window.requestAnimationFrame ||
+    window.webkitRequestAnimationFrame ||
+    window.mozRequestAnimationFrame    ||
+    window.oRequestAnimationFrame      ||
+    window.msRequestAnimationFrame     ||
+    function( callback ){
+    window.setTimeout(callback, 1000 / 60);
+  };
+})();
+
+var Paint = function(options) {
+  var canvas = options.el;
+  // Size the canvas
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  // Set the default line style.
+  var ctx = canvas.getContext("2d");
+  // ctx.lineWidth = options.size || Math.ceil(Math.random() * 35);
+  ctx.lineCap = options.lineCap || "round";
+
+
+  this.ctx = ctx;
+  this.canvas = canvas;
+  // All of the lines associated with a pointer.
+  this.lines = {};
+  // All of the pointers currently on the screen.
+  this.pointers = {};
+
+  this.initEvents();
+
+
+  // Setup render loop.
+  requestAnimFrame(this.renderLoop.bind(this));
+};
+
+Paint.prototype.initEvents = function() {
+  var canvas = this.canvas;
+  canvas.addEventListener('down', this.onDown.bind(this));
+  canvas.addEventListener('track', this.onTrack.bind(this));
+  canvas.addEventListener('up', this.onUp.bind(this));
+};
+
+Paint.prototype.onDown = function(event) {
+  console.log(event);
+  var width = event.pointerType === 'touch' ? (event.width || 10) : 4;
+  this.pointers[event.pointerId] = new Pointer({x: event.clientX, y: event.clientY, width: width});
+};
+
+Paint.prototype.onTrack = function(event) {
+  var pointer = this.pointers[event.pointerId];
+  // Check if there's a pointer that's down.
+  if (pointer) {
+    pointer.setTarget({x: event.clientX, y: event.clientY});
+    //console.log('pointers', pointer);
+  }
+};
+
+Paint.prototype.onUp = function(event) {
+  delete this.pointers[event.pointerId];
+};
+
+Paint.prototype.renderLoop = function(lastRender) {
+  // Go through all pointers, rendering the last segment.
+  for (var pointerId in this.pointers) {
+    var pointer = this.pointers[pointerId];
+    if (pointer.isDelta()) {
+      //console.log('rendering', pointer.targetX);
+      var ctx = this.ctx;
+      ctx.lineWidth = pointer.width;
+      ctx.strokeStyle = pointer.color;
+      ctx.beginPath();
+      ctx.moveTo(pointer.x, pointer.y);
+
+      ctx.lineTo(pointer.targetX, pointer.targetY);
+      ctx.stroke();
+      ctx.closePath();
+
+      pointer.didReachTarget();
+    }
+  }
+  requestAnimFrame(this.renderLoop.bind(this));
+};
+
+function Pointer(options) {
+  this.x = options.x;
+  this.y = options.y;
+  this.width = options.width;
+
+  // Pick a random color.
+  this.color = Pointer.COLORS[Math.floor(Math.random() * Pointer.COLORS.length)];
+}
+Pointer.COLORS = ["red", "green", "yellow", "blue", "magenta", "orangered"];
+
+Pointer.prototype.setTarget = function(options) {
+  this.targetX = options.x;
+  this.targetY = options.y;
+};
+
+Pointer.prototype.didReachTarget = function() {
+  this.x = this.targetX;
+  this.y = this.targetY;
+};
+
+Pointer.prototype.isDelta = function() {
+  return this.targetX && this.targetY &&
+      (this.x != this.targetX || this.y != this.targetY);
+}

--- a/samples/paint/paint.js
+++ b/samples/paint/paint.js
@@ -44,7 +44,6 @@ Paint.prototype.initEvents = function() {
 };
 
 Paint.prototype.onDown = function(event) {
-  console.log(event);
   var width = event.pointerType === 'touch' ? (event.width || 10) : 4;
   this.pointers[event.pointerId] = new Pointer({x: event.clientX, y: event.clientY, width: width});
 };

--- a/samples/tracker/index.html
+++ b/samples/tracker/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+ Copyright 2012-2014 The Polymer Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style
+ license that can be found in the LICENSE file.
+-->
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <meta name="viewport" content="width=device-width; height=device-height; initial-scale=1.0; maximum-scale=1.0;" /> 
+    <title>PointerEvents Tracker</title>
+    <style type="text/css"> 
+
+      * {
+        -webkit-touch-callout: none; /* prevent callout to copy image, etc when tap to hold */
+        -webkit-text-size-adjust: none; /* prevent webkit from resizing text to fit */
+        /* make transparent link selection, adjust last value opacity 0 to 1.0 */
+        -webkit-tap-highlight-color: rgba(0,0,0,0); 
+        -webkit-user-select: none; /* prevent copy paste, to allow, change 'none' to 'text' */
+        -webkit-tap-highlight-color: rgba(0,0,0,0); 
+      }
+
+      body {
+        background-color: #000000;
+        margin: 0px;
+      }
+      canvas {
+        background-color:#111133;
+        display:block; 
+        position:absolute; 
+      }
+      .container {
+        width:auto;
+        text-align:center;
+        background-color:#ff0000;
+      }
+    </style>
+
+
+  </head>
+  <body onload = "init()">
+    <script src="../../polymer-gestures.js"></script>
+    <script>
+
+// shim layer with setTimeout fallback
+window.requestAnimFrame = (function(){
+  return  window.requestAnimationFrame       ||
+  window.webkitRequestAnimationFrame ||
+  window.mozRequestAnimationFrame    ||
+  window.oRequestAnimationFrame      ||
+  window.msRequestAnimationFrame     ||
+  function( callback ){
+    window.setTimeout(callback, 1000 / 60);
+  };
+})();
+
+var canvas,
+c, // c is the canvas' context 2D
+container;
+
+setupCanvas();
+var pointers;
+
+
+canvas.addEventListener( 'down', onDown, false );
+canvas.addEventListener( 'track', onTrack, false );
+canvas.addEventListener( 'up', onUp, false );
+window.onorientationchange = resetCanvas;
+window.onresize = resetCanvas;
+
+function resetCanvas (e) {
+  // resize the canvas - but remember - this clears the canvas too.
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  //make sure we scroll to the top left.
+  window.scrollTo(0,0); 
+}
+
+function init(){
+  pointers = {};
+  requestAnimFrame(draw);
+}
+
+function draw() {
+  c.clearRect(0,0,canvas.width, canvas.height); 
+
+  for(var pointerId in pointers)
+  {
+    var pointer = pointers[pointerId]; 
+    c.beginPath(); 
+    c.fillStyle = "white";
+    c.fillText(pointer.pointerType+ " pointerId : "+pointer.pointerId+" x:"+pointer.x+" y:"+pointer.y, pointer.x+30, pointer.y-30); 
+
+    c.beginPath(); 
+    c.strokeStyle = "cyan";
+    c.lineWidth = "6";
+    c.arc(pointer.x, pointer.y, 40, 0, Math.PI*2, true); 
+    c.stroke();
+  }
+  //c.fillText("hello", 0,0); 
+
+  requestAnimFrame(draw);
+}
+
+function onDown(e) {
+  pointers[e.pointerId] = {
+    x: e.clientX,
+    y: e.clientY,
+    pointerType: e.pointerType,
+    pointerId: e.pointerId
+  };
+}
+
+function onTrack(e) {
+  // Prevent the browser from doing its default thing (scroll, zoom)
+  var pointer = pointers[e.pointerId];
+  if (pointer) {
+    pointer.x = e.clientX;
+    pointer.y = e.clientY;
+  }
+} 
+
+function onUp(e) { 
+  delete pointers[e.pointerId];
+}
+
+
+function setupCanvas() {
+
+  canvas = document.createElement( 'canvas' );
+  canvas.setAttribute( 'touch-action', 'none' );
+  c = canvas.getContext( '2d' );
+  container = document.createElement( 'div' );
+  container.className = "container";
+
+  canvas.width = window.innerWidth; 
+  canvas.height = window.innerHeight; 
+  document.body.appendChild( container );
+  container.appendChild(canvas);  
+
+  c.strokeStyle = "#ffffff";
+  c.lineWidth =2; 
+}
+
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR is not ready to merge just yet.

I'm working on adding the examples from PointerEvents over to polymer-gestures. I've noticed that in the paint and tracker example, if I have a second pointer, the track event does not fire for that pointer. Is there a way to track multiple touch points in polymer-gestures?

@azakus
