### PR TITLE
Rename flick gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supported events:
     * Can be prevented by calling any gesture event's preventTap function
 
 Not yet implemented:
-* flick
+* swipe
 * hold
 * holdpulse
 * release


### PR DESCRIPTION
According to android & iOS references `flick` gesture should be called `swipe`.
# Details

http://developer.android.com/design/patterns/gestures.html

<blockquote>
Swipe or drag

Scrolls overflowing content, or navigates between views in the same hierarchy. Swipes are quick and affect the screen even after the finger is picked up. Drags are slower and more precise, and the screen stops responding when the finger is picked up.
</blockquote>


https://developer.apple.com/library/ios/documentation/EventHandling/Conceptual/EventHandlingiPhoneOS/GestureRecognizer_basics/GestureRecognizer_basics.html
https://developer.apple.com/library/ios/documentation/UIKit/Reference/UISwipeGestureRecognizer_Class/Reference/Reference.html#//apple_ref/occ/cl/UISwipeGestureRecognizer

<blockquote>
Gesture recognizers interpret touches to determine whether they correspond to a specific gesture, such as a swipe, pinch, or rotation.</blockquote>
<blockquote>
UISwipeGestureRecognizer recognizes a swipe when the specified number of touches (numberOfTouchesRequired) have moved mostly in an allowable direction (direction) far enough to be considered a swipe. Swipes can be slow or fast. A slow swipe requires high directional precision but a small distance; a fast swipe requires low directional precision but a large distance.
</blockquote>

# P.S.

`swipe` gesture is more popular in other touch-events framework. That should ease the transition from them to `polymer-gestures`.
