### PR TITLE
added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Just added [.editorconfig](http://editorconfig.org/) for convenience ;)

By default a lot of people has 4 spaces indentation, but in polymer — 2 spaces. Editorconfig can help in this difference.
