### PR TITLE
Fixed undefined body

### DIFF
--- a/src/platform-events.js
+++ b/src/platform-events.js
@@ -32,7 +32,7 @@
        */
       var isSafari = nav.userAgent.match('Safari') && !nav.userAgent.match('Chrome');
       if (isSafari) {
-        document.addEventListener('DOMContentLoaded', function(event) {
+        document.addEventListener('DOMContentLoaded', function() {
           document.body.addEventListener('touchstart', function(){});
         });
       }

--- a/src/platform-events.js
+++ b/src/platform-events.js
@@ -32,7 +32,9 @@
        */
       var isSafari = nav.userAgent.match('Safari') && !nav.userAgent.match('Chrome');
       if (isSafari) {
-        document.body.addEventListener('touchstart', function(){});
+        document.addEventListener('DOMContentLoaded', function(event) {
+          document.body.addEventListener('touchstart', function(){});
+        });
       }
     }
   }


### PR DESCRIPTION
At least now in examples `polymer gestures` are included in `head` tag. So in time they are executed we have no `document.body` element. This cause a lot of errors in console of mobile safari.

Fixes #53 
