### PR TITLE
Fix finding targets

### DIFF
--- a/src/targetfind.js
+++ b/src/targetfind.js
@@ -120,7 +120,7 @@
         }
       } else {
         n = inEvent.target;
-        while(n) {
+        while(n && typeof n.hasAttribute === 'function') {
           if (n.hasAttribute('touch-action')) {
             return n.getAttribute('touch-action');
           }


### PR DESCRIPTION
In mobile safari at least on each move action we trying to find `touch-action` property, but we have error here:

``` js
    findTouchAction: function(inEvent) {
      var n;
      if (HAS_FULL_PATH && inEvent.path) {
        var path = inEvent.path;
        for (var i = 0; i < path.length; i++) {
          n = path[i];
          if (n.nodeType === Node.ELEMENT_NODE && n.hasAttribute('touch-action')) {
            return n.getAttribute('touch-action');
          }
        }
      } else {
        n = inEvent.target;
        while(n) {
          if (n.hasAttribute('touch-action')) {
            return n.getAttribute('touch-action');
          }
          n = n.parentNode || n.host;
        }
      }
      // auto is default
      return "auto";
    },
```

Sometimes `n` doesn't have method `hasAttribute`. I did not search for the reason, but for workaround we can add

``` js
typeof n.hasAttribute === 'function'
```

in condition.

I will search for the real issue later.
