### PR TITLE
pinch/rotate bubbles, cancelable

### DIFF
--- a/src/pinch.js
+++ b/src/pinch.js
@@ -69,6 +69,10 @@
       'pinch',
       'rotate'
     ],
+    defaultActions: {
+      'pinch': 'none',
+      'rotate': 'none'
+    },
     reference: {},
     down: function(inEvent) {
       pointermap.set(inEvent.pointerId, inEvent);
@@ -102,18 +106,24 @@
     firePinch: function(diameter, points) {
       var zoom = diameter / this.reference.diameter;
       var e = eventFactory.makeGestureEvent('pinch', {
+        bubbles: true,
+        cancelable: true,
         scale: zoom,
         centerX: points.center.x,
-        centerY: points.center.y
+        centerY: points.center.y,
+        _source: 'pinch'
       });
       this.reference.target.dispatchEvent(e);
     },
     fireRotate: function(angle, points) {
       var diff = Math.round((angle - this.reference.angle) % 360);
       var e = eventFactory.makeGestureEvent('rotate', {
+        bubbles: true,
+        cancelable: true,
         angle: diff,
         centerX: points.center.x,
-        centerY: points.center.y
+        centerY: points.center.y,
+        _source: 'pinch'
       });
       this.reference.target.dispatchEvent(e);
     },


### PR DESCRIPTION
Fixes from #49 
- [x] Since pinch and rotate need to prevent scrolling, the recognizer needs to have defaultActions of none for the pinch and rotate gesture like this: https://github.com/Polymer/polymer-gestures/blob/master/src/track.js#L123-L127
- [x] The calls to makeGestureEvent should have bubbles: true, cancelable: true, and _source: "pinch" properties set.
  I made both events to have source "pinch", is it correct? Just it used only in tests and represents the "file" it came from?
- [ ] There should be some sample for rotate too, if only logging the angle.

For third item i'll made separate pull request with sample like [this](https://rozhdestvenskiy.ru/dev/gestures/polymer-gestures/samples/image/index.html) but it need https://github.com/Polymer/polymer-gestures/issues/60 to be fixed first.
