### PR TITLE
'bubbles' and 'cancelable' properties of an Event are not writable.  Fix...

### DIFF
--- a/src/eventFactory.js
+++ b/src/eventFactory.js
@@ -78,7 +78,9 @@
       var e = this.makeBaseEvent(inType, inDict);
       for (var i = 0, keys = Object.keys(inDict), k; i < keys.length; i++) {
         k = keys[i];
-        e[k] = inDict[k];
+        if( k !== 'bubbles' && k !== 'cancelable' ) {
+           e[k] = inDict[k];
+        }
       }
       return e;
     },
@@ -87,7 +89,7 @@
 
       var e = this.makeBaseEvent(inType, inDict);
       // define inherited MouseEvent properties
-      for(var i = 0, p; i < MOUSE_PROPS.length; i++) {
+      for(var i = 2, p; i < MOUSE_PROPS.length; i++) {
         p = MOUSE_PROPS[i];
         e[p] = inDict[p] || MOUSE_DEFAULTS[i];
       }


### PR DESCRIPTION
...ed code so it doesn't attempt to set those properties.

According to this:

https://developer.mozilla.org/en-US/docs/Web/API/Event.initEvent

'bubbles' and 'cancelable' properties of an Event are read-only.  They are set once when the Event is first initialized with 

e.initEvent(inType, inDict.bubbles || false, inDict.cancelable || false);

in makeBaseEvent(...)

The two places I found here attempt to write to those properties causing an exception when running a polymer mobile chrome app on iOS 8.1 (build with cca tool).

Related: https://github.com/webcomponents/webcomponentsjs/pull/122
