### PR TITLE
Update Karma to fix problems with peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "grunt": "^0.4.4",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-uglify": "^0.4.0",
-    "karma": "~0.12.0",
+    "karma": "^0.13.0",
     "karma-mocha": "*",
     "karma-firefox-launcher": "*",
     "karma-ie-launcher": "*",


### PR DESCRIPTION
A fresh checkout won't let you run ```npm install`` because the karma dependency has been updated in one of the peer dependencies. 

Changed the prefix to accept newer minor versions + updating to the current one.

npm ERR! peerinvalid The package karma does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma-crbot-reporter@0.0.4 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-safari-launcher@0.1.1 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-script-launcher@0.1.0 wants karma@>=0.9
npm ERR! peerinvalid Peer grunt-karma@0.12.0 wants karma@^0.13.0 || >= 0.14.0-rc.0
npm ERR! peerinvalid Peer karma-ie-launcher@0.2.0 wants karma@>=0.9